### PR TITLE
Fix for SMBS Marathon achievements not being achievable

### DIFF
--- a/Scripts/Classes/Singletons/SpeedrunHandler.gd
+++ b/Scripts/Classes/Singletons/SpeedrunHandler.gd
@@ -123,7 +123,6 @@ const SMBLL_LEVEL_GOLD_ANY_TIMES := {
 }
 
 const SMBS_LEVEL_GOLD_ANY_TIMES := {
-	"1-2": 25,
 	"4-2": 30
 }
 


### PR DESCRIPTION
looks like SOMEBODY left their 1-2 any% time in the array. wonder who that was. looks at the joemama in the room